### PR TITLE
[FIX] Fix pluralization for Total Character text

### DIFF
--- a/savebook/components/notes/Notes.js
+++ b/savebook/components/notes/Notes.js
@@ -332,7 +332,11 @@ export default function Notes() {
                                 <div className="text-3xl font-bold text-white mb-2">
                                     {filteredNotes.reduce((total, note) => total + (note.description?.length || 0), 0).toLocaleString()}
                                 </div>
-                                <div className="text-gray-400 text-sm">Total Character</div>
+                                <div className="text-gray-400 text-sm">
+                                    {filteredNotes.reduce((total, note) => total + (note.description?.length || 0), 0) === 1
+                                        ? "1 Character"
+                                        : "Total Characters"}
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## Description

Fixes a small UI text issue where "Total Character" was always shown.
Now the label correctly shows singular or plural based on the character count.

Fixes #59

## Type of change

- [x] Bug fix (non-breaking change)

## How Has This Been Tested?
- Manually tested by creating notes
- Verified that:
  - 1 character shows "1 Character"
  - More than 1 character shows "Total Characters"
  -

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings