### PR TITLE
feat: added Password Visibility Toggle

### DIFF
--- a/savebook/app/(auth)/login/page.js
+++ b/savebook/app/(auth)/login/page.js
@@ -6,6 +6,8 @@ import React, { useState, useEffect } from "react";
 import toast from "react-hot-toast";
 import Link from "next/link";
 
+import { Eye, EyeOff } from "lucide-react";
+
 /* =========================
    Login Form
 ========================= */
@@ -20,6 +22,7 @@ const LoginForm = () => {
 
   const [isLoading, setIsLoading] = useState(false);
   const [hasRedirected, setHasRedirected] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
 
   //  Recovery Codes
   const [recoveryCodes, setRecoveryCodes] = useState(null);
@@ -134,16 +137,26 @@ const LoginForm = () => {
               Forgot password?
             </Link>
           </div>
-          <input
-            type="password"
-            name="password"
-            value={credentials.password}
-            onChange={onchange}
-            required
-            disabled={isLoading}
-            className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white"
-            placeholder="Enter password"
-          />
+          <div className="relative">
+            <input
+              type={showPassword ? "text" : "password"}
+              name="password"
+              value={credentials.password}
+              onChange={onchange}
+              required
+              disabled={isLoading}
+              className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white pr-10 focus:ring-2 focus:ring-blue-500 outline-none"
+              placeholder="Enter password"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+              aria-label={showPassword ? "Hide password" : "Show password"}
+            >
+              {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+            </button>
+          </div>
         </div>
 
         {/* Submit */}
@@ -172,7 +185,7 @@ const LoginForm = () => {
             </h3>
 
             <p className="text-sm text-gray-300 mb-4">
-              These codes will be shown only once.  
+              These codes will be shown only once.
               Save them securely.
             </p>
 

--- a/savebook/app/(auth)/register/page.js
+++ b/savebook/app/(auth)/register/page.js
@@ -5,11 +5,13 @@ import React, { useState, useEffect } from 'react';
 import toast from 'react-hot-toast';
 import Link from 'next/link';
 
+import { Eye, EyeOff } from 'lucide-react';
+
 // Signup Form Component
 const SignupForm = () => {
     const { register, isAuthenticated } = useAuth();
-    const [credentials, setCredentials] = useState({ 
-        username: '', 
+    const [credentials, setCredentials] = useState({
+        username: '',
         password: '',
         confirmPassword: ''
     });
@@ -19,6 +21,8 @@ const SignupForm = () => {
         confirmPassword: ''
     });
     const [isLoading, setIsLoading] = useState(false);
+    const [showPassword, setShowPassword] = useState(false);
+    const [showConfirmPassword, setShowConfirmPassword] = useState(false);
     const router = useRouter();
 
     // Handle redirection based on authentication status
@@ -30,16 +34,16 @@ const SignupForm = () => {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        
+
         // Prevent submission if already authenticated
         if (isAuthenticated) {
             router.push("/");
             return;
         }
-        
+
         // Validate and collect errors
         const newErrors = {};
-        
+
         if (!credentials.username.trim()) {
             newErrors.username = 'Username is required';
         }
@@ -63,14 +67,14 @@ const SignupForm = () => {
         }
 
         setIsLoading(true);
-        
+
         try {
             // Use the register method from AuthContext
             const result = await register(
                 credentials.username,
                 credentials.password
             );
-            
+
             if (result.success) {
                 toast.success("Account created successfully! 🎉");
                 router.push("/login")
@@ -80,15 +84,15 @@ const SignupForm = () => {
             }
         } catch (error) {
             console.error("Registration error:", error);
-            
+
             // Attempt to extract meaningful error message
             let errorMessage = "Something went wrong. Please try again.";
-            
+
             try {
                 // Check if response exists and extract message from JSON
                 if (error.response?.data) {
                     const data = error.response.data;
-                    
+
                     // Try to get message from JSON response
                     if (typeof data === 'object' && data !== null) {
                         if (data.message) {
@@ -103,7 +107,7 @@ const SignupForm = () => {
                         throw new Error('HTML_RESPONSE');
                     }
                 }
-                
+
                 // Handle HTTP status codes if no JSON message was found
                 if (errorMessage.includes('Something went wrong')) {
                     if (error.response?.status === 500) {
@@ -124,7 +128,7 @@ const SignupForm = () => {
                     errorMessage = error.message;
                 }
             }
-            
+
             toast.error(errorMessage);
         } finally {
             setIsLoading(false);
@@ -156,11 +160,10 @@ const SignupForm = () => {
                     value={credentials.username}
                     onChange={onchange}
                     disabled={isLoading || isAuthenticated}
-                    className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:border-blue-500 transition-all duration-200 outline-none disabled:opacity-50 ${
-                        errors.username 
-                            ? 'border-red-500 bg-red-900/20 focus:ring-red-500' 
+                    className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:border-blue-500 transition-all duration-200 outline-none disabled:opacity-50 ${errors.username
+                            ? 'border-red-500 bg-red-900/20 focus:ring-red-500'
                             : 'border-gray-600 bg-gray-700 text-white focus:ring-blue-500'
-                    }`}
+                        }`}
                     placeholder="Choose a username"
                     required
                 />
@@ -174,21 +177,30 @@ const SignupForm = () => {
                 <label htmlFor="password" className="block text-sm font-medium text-gray-300 mb-2">
                     Password
                 </label>
-                <input
-                    type="password"
-                    name="password"
-                    id="password"
-                    value={credentials.password}
-                    onChange={onchange}
-                    disabled={isLoading || isAuthenticated}
-                    className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:border-blue-500 transition-all duration-200 outline-none disabled:opacity-50 ${
-                        errors.password 
-                            ? 'border-red-500 bg-red-900/20 focus:ring-red-500' 
-                            : 'border-gray-600 bg-gray-700 text-white focus:ring-blue-500'
-                    }`}
-                    placeholder="Create a password"
-                    required
-                />
+                <div className="relative">
+                    <input
+                        type={showPassword ? "text" : "password"}
+                        name="password"
+                        id="password"
+                        value={credentials.password}
+                        onChange={onchange}
+                        disabled={isLoading || isAuthenticated}
+                        className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:border-blue-500 transition-all duration-200 outline-none disabled:opacity-50 pr-10 ${errors.password
+                                ? 'border-red-500 bg-red-900/20 focus:ring-red-500'
+                                : 'border-gray-600 bg-gray-700 text-white focus:ring-blue-500'
+                            }`}
+                        placeholder="Create a password"
+                        required
+                    />
+                    <button
+                        type="button"
+                        onClick={() => setShowPassword(!showPassword)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                        aria-label={showPassword ? "Hide password" : "Show password"}
+                    >
+                        {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                    </button>
+                </div>
                 {errors.password && (
                     <p className="mt-1 text-sm text-red-400">{errors.password}</p>
                 )}
@@ -202,21 +214,30 @@ const SignupForm = () => {
                 <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-300 mb-2">
                     Confirm Password
                 </label>
-                <input
-                    type="password"
-                    name="confirmPassword"
-                    id="confirmPassword"
-                    value={credentials.confirmPassword}
-                    onChange={onchange}
-                    disabled={isLoading || isAuthenticated}
-                    className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:border-blue-500 transition-all duration-200 outline-none disabled:opacity-50 ${
-                        errors.confirmPassword 
-                            ? 'border-red-500 bg-red-900/20 focus:ring-red-500' 
-                            : 'border-gray-600 bg-gray-700 text-white focus:ring-blue-500'
-                    }`}
-                    placeholder="Confirm your password"
-                    required
-                />
+                <div className="relative">
+                    <input
+                        type={showConfirmPassword ? "text" : "password"}
+                        name="confirmPassword"
+                        id="confirmPassword"
+                        value={credentials.confirmPassword}
+                        onChange={onchange}
+                        disabled={isLoading || isAuthenticated}
+                        className={`w-full px-4 py-3 border rounded-lg focus:ring-2 focus:border-blue-500 transition-all duration-200 outline-none disabled:opacity-50 pr-10 ${errors.confirmPassword
+                                ? 'border-red-500 bg-red-900/20 focus:ring-red-500'
+                                : 'border-gray-600 bg-gray-700 text-white focus:ring-blue-500'
+                            }`}
+                        placeholder="Confirm your password"
+                        required
+                    />
+                    <button
+                        type="button"
+                        onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                        aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+                    >
+                        {showConfirmPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                    </button>
+                </div>
                 {errors.confirmPassword && (
                     <p className="mt-1 text-sm text-red-400">{errors.confirmPassword}</p>
                 )}
@@ -245,8 +266,8 @@ const SignupForm = () => {
             <div className="text-center">
                 <span className="text-sm text-gray-300">
                     Already have an account?{' '}
-                    <Link 
-                        href="/login" 
+                    <Link
+                        href="/login"
                         className="font-medium text-green-400 hover:text-green-300"
                         onClick={(e) => {
                             if (isLoading || isAuthenticated) {

--- a/savebook/app/(auth)/reset-password/page.jsx
+++ b/savebook/app/(auth)/reset-password/page.jsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import Link from "next/link";
+import { Eye, EyeOff } from "lucide-react";
 
 export default function ResetPasswordPage() {
   const router = useRouter();
@@ -11,6 +12,8 @@ export default function ResetPasswordPage() {
   const [recoveryCode, setRecoveryCode] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [message, setMessage] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -52,9 +55,9 @@ export default function ResetPasswordPage() {
         }),
       });
 
-      
+
       const data = await res.json();
-      
+
 
       if (!res.ok) {
         setMessage(data.message || "Reset failed");
@@ -125,14 +128,24 @@ export default function ResetPasswordPage() {
               <label className="block text-sm font-medium text-gray-300 mb-2">
                 New Password
               </label>
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-blue-500 outline-none"
-                placeholder="Enter new password"
-              />
+              <div className="relative">
+                <input
+                  type={showPassword ? "text" : "password"}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                  className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-blue-500 outline-none pr-10"
+                  placeholder="Enter new password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                  aria-label={showPassword ? "Hide password" : "Show password"}
+                >
+                  {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                </button>
+              </div>
             </div>
 
             {/* Confirm Password */}
@@ -140,14 +153,24 @@ export default function ResetPasswordPage() {
               <label className="block text-sm font-medium text-gray-300 mb-2">
                 Confirm Password
               </label>
-              <input
-                type="password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-blue-500 outline-none"
-                placeholder="Confirm new password"
-              />
+              <div className="relative">
+                <input
+                  type={showConfirmPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  className="w-full px-4 py-3 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-blue-500 outline-none pr-10"
+                  placeholder="Confirm new password"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-200 focus:outline-none"
+                  aria-label={showConfirmPassword ? "Hide password" : "Show password"}
+                >
+                  {showConfirmPassword ? <EyeOff size={20} /> : <Eye size={20} />}
+                </button>
+              </div>
             </div>
 
             {/* Submit */}

--- a/savebook/app/globals.css
+++ b/savebook/app/globals.css
@@ -3,3 +3,9 @@
 body{
     background-color:#101828;
 }
+
+/* Hide default browser password reveal button */
+input::-ms-reveal,
+input::-ms-clear {
+  display: none;
+}


### PR DESCRIPTION
## Description

This PR adds a Password Visibility Toggle (Show/Hide) to the Login, Register, and Reset Password forms. Users can now click an eye icon to toggle the visibility of their password, reducing typing errors and improving usability, especially on mobile devices.

Additionally, browser-default password reveal buttons are hidden via CSS to prevent duplicate icons in browsers like Edge.

Fixes #35 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

##Screenshot

<img width="1273" height="771" alt="image" src="https://github.com/user-attachments/assets/6b05446a-4cc0-42be-a110-8dd91f6025c6" />


## How Has This Been Tested?

Manual Verification:

- Verified the toggle functionality on the Login page.
- Verified independent toggles for Password and Confirm Password on the Register page.
- Verified independent toggles for New Password and Confirm Password on the Reset Password page.
- Verified that browser-default eye icons are hidden in Edge/Chrome..

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes