### PR TITLE
fix(footer): add privacy/terms links and fix broken Community list structure

### DIFF
--- a/savebook/components/common/Footer.js
+++ b/savebook/components/common/Footer.js
@@ -196,9 +196,27 @@ export default function Footer() {
                 >
                   Code of Conduct
                 </a>
+              </li>
+              <li>
+                <Link
+                  href="/privacy"
+                  className="text-sm text-[#94a3b8] hover:text-white transition-colors"
+                >
+                  Privacy Policy
+                </Link>
+              </li>
+              <li>
+                <Link
+                  href="/terms"
+                  className="text-sm text-[#94a3b8] hover:text-white transition-colors"
+                >
+                  Terms of Service
+                </Link>
+              </li>
+              <li>
                 <Link
                   href="/licence"
-                  className="text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 text-sm transition-colors"
+                  className="text-sm text-[#94a3b8] hover:text-white transition-colors"
                 >
                   MIT License
                 </Link>


### PR DESCRIPTION
## Problem

Fixes #233

The privacy page exists at `/privacy` (and terms at `/terms`) but there is no way for users to discover these pages from the main website. Additionally, the Community section in the footer has broken HTML structure where **Code of Conduct** and **MIT License** links are incorrectly nested inside a single `<li>` element, and the License link uses inconsistent styling.

## What I Fixed

### 1. Added Privacy Policy and Terms of Service links

Surfaced the existing legal pages in the footer so users can actually find them:
- **Privacy Policy** → `/privacy`
- **Terms of Service** → `/terms`

Both pages already exist in the codebase at:
- `savebook/app/(legal)/privacy/page.js`
- `savebook/app/(legal)/terms/page.js`

### 2. Fixed broken HTML structure

Before:
```jsx
<li>
  <a>Code of Conduct</a>   {/* missing </li> */}
  <Link>MIT License</Link> {/* nested inside same <li> */}
</li>
```

After:
```jsx
<li><a>Code of Conduct</a></li>
<li><Link>Privacy Policy</Link></li>
<li><Link>Terms of Service</Link></li>
<li><Link>MIT License</Link></li>
```

### 3. Normalized link styling

The MIT License link previously used `text-gray-600 dark:text-gray-400` which did not match the rest of the footer. All legal links now use `text-[#94a3b8] hover:text-white transition-colors` for visual consistency.

## Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| Privacy page discoverable | ❌ No link anywhere | ✅ Linked in footer |
| Terms page discoverable | ❌ No link anywhere | ✅ Linked in footer |
| HTML validity | ❌ Two links in one `<li>` | ✅ Proper list structure |
| Styling consistency | ❌ License link looks different | ✅ All links styled consistently |

## Why This Solution Is Correct

1. **No new dependencies or pages created** — leverages existing `(legal)` route group pages.
2. **Minimal change** — only touches the Community section of `Footer.js`.
3. **Accessibility improvement** — valid list structure helps screen readers navigate the footer correctly.
4. **Legal compliance** — privacy policies should be discoverable from every page; placing them in the global footer is standard practice.

## How to Test

1. Run the app and scroll to the footer on any page.
2. Confirm "Privacy Policy" and "Terms of Service" links appear in the Community column.
3. Click each link — they should navigate to `/privacy` and `/terms` respectively.
4. Verify the footer renders without console warnings about invalid DOM nesting.

---

I am happy to adjust the placement (e.g., move links to a separate **Legal** column) or styling based on maintainer feedback. 🙏
