### PR TITLE
Auto-add NSOC'26 label to new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+
+default:
+  labels:
+    - NSOC'26

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -2,20 +2,27 @@ name: Auto Label NSOC Issues
 
 on:
   issues:
-    types: [opened]
+    types:
+      - opened
+
+permissions:
+  issues: write
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   add-label:
+    name: Add NSOC'26 Label
     runs-on: ubuntu-latest
 
     steps:
       - name: Add NSOC'26 label
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const issue_number = context.issue.number;
 
-            // Apply label to every newly opened issue
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -15,6 +15,7 @@ jobs:
           script: |
             const issue_number = context.issue.number;
 
+            // Apply label to every newly opened issue
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,23 @@
+name: Auto Label NSOC Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add NSOC'26 label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue_number = context.issue.number;
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number,
+              labels: ["NSOC'26"]
+            });


### PR DESCRIPTION
## Description

Auto-add NSOC'26 label to new issues.

Fixes #237 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
Maintainers currently add the NSOC'26 label manually to each new issue. This is repetitive, time-consuming, and can lead to missed or inconsistent labeling..

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes