### PR TITLE
UI/add logo to navbar

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,97 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SaveBook</title>
+    <style>
+        :root {
+            color-scheme: light;
+            font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: linear-gradient(180deg, #f8fbff 0%, #eef4ff 100%);
+            color: #0f172a;
+        }
+
+        .page-shell {
+            width: min(960px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 32px 0 48px;
+        }
+
+        .brand-bar {
+            display: inline-flex;
+            align-items: center;
+            gap: 12px;
+            padding: 12px 18px;
+            border: 1px solid #d9e3f5;
+            border-radius: 999px;
+            background: rgba(255, 255, 255, 0.88);
+            box-shadow: 0 12px 34px rgba(15, 23, 42, 0.08);
+        }
+
+        .brand-bar img {
+            width: 28px;
+            height: 28px;
+            display: block;
+            object-fit: contain;
+        }
+
+        .brand-bar span {
+            font-size: 0.92rem;
+            font-weight: 700;
+            letter-spacing: 0.22em;
+            text-transform: uppercase;
+        }
+
+        .content-card {
+            margin-top: 28px;
+            padding: 32px;
+            border: 1px solid #d9e3f5;
+            border-radius: 28px;
+            background: rgba(255, 255, 255, 0.9);
+            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+        }
+
+        h1 {
+            margin: 0 0 12px;
+            font-size: clamp(2rem, 4vw, 3rem);
+        }
+
+        p {
+            margin: 0;
+            line-height: 1.6;
+            color: #475569;
+        }
+
+        @media (max-width: 640px) {
+            .page-shell {
+                width: min(100% - 24px, 960px);
+                padding-top: 20px;
+            }
+
+            .content-card {
+                padding: 24px;
+                border-radius: 24px;
+            }
+        }
+    </style>
 </head>
 <body>
-    SaveBook Documentation
+    <main class="page-shell">
+        <div class="brand-bar">
+            <img src="../savebook/public/savebook.png" alt="SaveBook logo">
+            <span>SaveBook</span>
+        </div>
+        <section class="content-card">
+            <h1>SaveBook Documentation</h1>
+            <p>The docs page now includes the SaveBook logo so the brand stays visible alongside the app experience.</p>
+        </section>
+    </main>
 </body>
 </html>

--- a/savebook/components/common/Navbar.js
+++ b/savebook/components/common/Navbar.js
@@ -2,8 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import { clsx } from "clsx";
-import { Menu, NotebookPen, User, X } from "lucide-react";
+import { Menu, User, X } from "lucide-react";
 import { useAuth } from "@/context/auth/authContext";
 import ThemeToggle from "@/components/common/ThemeToggle";
 
@@ -67,8 +68,14 @@ export default function Navbar() {
         href="/"
         className="inline-flex items-center gap-3 rounded-full border border-[var(--border)] bg-[color:var(--background-elevated)] px-4 py-2 text-sm font-semibold uppercase tracking-[0.28em] text-[color:var(--foreground)] shadow-[0_14px_40px_rgba(15,23,42,0.08)]"
       >
-        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-gradient-to-br from-sky-500 via-blue-500 to-violet-500 text-white shadow-[0_16px_36px_rgba(59,130,246,0.34)]">
-          <NotebookPen className="h-4 w-4" />
+        <span className="flex h-9 w-9 items-center justify-center">
+          <Image
+            src="/savebook.png"
+            alt="SaveBook logo"
+            width={22}
+            height={22}
+            className="h-[22px] w-[22px] object-contain"
+          />
         </span>
         SaveBook
       </Link>


### PR DESCRIPTION
## Description

Updates SaveBook branding so the logo displays consistently in the shared app navbar and on the standalone docs page. The navbar now uses the public `savebook.png` asset instead of the `NotebookPen` icon, and the extra icon background color has been removed for a cleaner look. The docs page was also updated to show the same SaveBook branding.

Fixes #168 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Screenshots
<img width="1884" height="835" alt="image" src="https://github.com/user-attachments/assets/bd8bc7bf-807a-4315-9494-05c50cfc28dd" />


## How Has This Been Tested?

- Started the local development server with `npm run dev`
- Verified the shared navbar renders the SaveBook logo in the app
- Confirmed the logo asset loads successfully from `/savebook.png`
- Confirmed the optimized Next image endpoint returns `200`
- Verified the docs page now includes SaveBook logo branding

Reproduce:
1. Run `npm install`
2. Copy `.env.local.example` to `.env.local`
3. Run `npm run dev` inside `savebook`
4. Open `http://localhost:3000`
5. Open the docs page and confirm the SaveBook logo is visible there as well

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
